### PR TITLE
OK-643 haku otsikolla ja sisällöllä käliin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Lokaalin ympäristön käyttöönotto
    yhteydessä luodaan tarvittavat komponentit localstackiin (S3-bucketit, SQS-jonot)
 5. Kirjaudu sisään sovellukseen menemällä osoitteeseen: https://localhost:8080/login (tunnukset esim. user/password)
 6. Mene osoitteeseen: https://localhost:8080/swagger, kaikkia kutsuja pitäisi pystyä kokeilemaan esimerkkiparametreilla
-7. Järjestelmän tilaa voi seurata kannasta (salasana on "app"): psql -U app --host localhost -d viestinvalitys
+7. Järjestelmän tilaa voi seurata kannasta (salasana on "app"): psql -U app --host localhost -d viestinvalityspalvelu
 
 Lähtökohtaisesti mailit ohjautuvat MailCatcheriin joka löytyy osoitteesta http://localhost:1080. Lähetetyn viestin tilan
 päivitystä (SES -eventtejä) voi testata liittämällä vastaanottajan nimiosaan liitteen +success (esim. vallu.vastaanottaja+success@example.com),

--- a/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/model/LahetyksetParamValidator.scala
+++ b/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/model/LahetyksetParamValidator.scala
@@ -16,7 +16,8 @@ case class VastaanottajatParams(lahetysTunniste: String,
 case class LahetyksetParams(alkaen: Optional[String],
                             enintaan: Optional[String],
                             vastaanottajanEmail: Optional[String],
-                            organisaatio: Optional[String])
+                            organisaatio: Optional[String],
+                            viesti: Optional[String])
 object LahetyksetParamValidator {
 
   def validateAlkaenUUID(alkaen: Optional[String]): Set[String] =
@@ -62,6 +63,13 @@ object LahetyksetParamValidator {
         if (organisaatio.isPresent && !OrganisaatioOid.isValid(organisaatio.get())) Left(virheet.incl(ORGANISAATIO_INVALID)) else Right(virheet))
       .fold(l => l, r => r)
 
+  def validateHakusanaParam(hakusanaParam: Optional[String]): Set[String] =
+    val validatedHakusana = ParametriUtil.asValidHakusana(hakusanaParam)
+    Right(Set.empty.asInstanceOf[Set[String]])
+      .flatMap(virheet =>
+        if (hakusanaParam.isPresent && validatedHakusana.isEmpty) Left(virheet.incl(HAKUSANA_INVALID)) else Right(virheet))
+      .fold(l => l, r => r)
+  
   def validateVastaanottajatParams(params: VastaanottajatParams): Seq[String] =
     Seq(
       validateLahetysTunniste(params.lahetysTunniste),
@@ -77,6 +85,7 @@ object LahetyksetParamValidator {
       validateAlkaenUUID(params.alkaen),
       validateEnintaan(params.enintaan, LAHETYKSET_ENINTAAN_MIN, LAHETYKSET_ENINTAAN_MAX, LAHETYKSET_ENINTAAN_INVALID),
       validateEmailParam(params.vastaanottajanEmail, VASTAANOTTAJA_INVALID),
-      validateOrganisaatio(params.organisaatio)
+      validateOrganisaatio(params.organisaatio),
+      validateHakusanaParam(params.viesti)
     ).flatten
 }

--- a/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/RaportointiApiConstants.scala
+++ b/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/RaportointiApiConstants.scala
@@ -23,6 +23,7 @@ object RaportointiAPIConstants {
   final val TILA_PARAM_NAME                   = "tila"
   final val VASTAANOTTAJA_PARAM_NAME          = "vastaanottaja"
   final val ORGANISAATIO_PARAM_NAME           = "organisaatio"
+  final val VIESTI_SISALTO_PARAM_NAME         = "viesti"
 
   final val VIESTI_PATH                      = VERSIONED_RAPORTOINTI_API_PREFIX + "/viesti"
   final val VIESTITUNNISTE_PARAM_NAME         = "viestiTunniste"
@@ -70,6 +71,8 @@ object RaportointiAPIConstants {
   final val VASTAANOTTAJAT_ENINTAAN_DEFAULT   = VASTAANOTTAJAT_ENINTAAN_DEFAULT_STR.toInt
   final val VASTAANOTTAJAT_ENINTAAN_DEFAULT_STR  = "256"
   final val emailRegex = "^[^\\s,@]+@(([a-zA-Z\\-0-9])+\\.)+([a-zA-Z\\-0-9]){2,}$".r
+  final val HAKUSANA_MIN_LENGTH               = 5
+  final val HAKUSANA_MAX_LENGTH               = 150
 
   /**
    * Virhetilanteisiin liittyvät vakiot
@@ -82,7 +85,8 @@ object RaportointiAPIConstants {
   final val VIESTITUNNISTE_INVALID            = "Tunniste ei ole muodoltaan validi uuid"
   final val LAHETYSTUNNISTE_INVALID           = "Lähetystunniste ei ole muodoltaan validi uuid"
   final val ORGANISAATIO_INVALID              = "Organisaation oid ei ole validi"
-
+  final val HAKUSANA_INVALID                  = "Hakusana ei ole validi"
+  
   final val ALKAEN_UUID_TUNNISTE_INVALID      = ALKAEN_PARAM_NAME + "-parametri: Tunniste ei ole muodoltaan validi uuid"
   final val VASTAANOTTAJAT_ENINTAAN_INVALID   = ENINTAAN_PARAM_NAME + "-parametri: Arvon pitää olla numero väliltä " + VASTAANOTTAJAT_ENINTAAN_MIN_STR + "-" + VASTAANOTTAJAT_ENINTAAN_MAX_STR
   final val LAHETYKSET_ENINTAAN_INVALID       = ENINTAAN_PARAM_NAME + "-parametri: Arvon pitää olla numero väliltä " + LAHETYKSET_ENINTAAN_MIN_STR + "-" + LAHETYKSET_ENINTAAN_MAX_STR

--- a/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/Util.scala
+++ b/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/Util.scala
@@ -47,6 +47,12 @@ object ParametriUtil {
       Option.empty
     else
       Option.apply(parametri.get())
+      
+  def asValidHakusana(parametri: Optional[String]): Option[String] =
+    if (!parametri.isPresent || (parametri.get().length < RaportointiAPIConstants.HAKUSANA_MIN_LENGTH) || (parametri.get().length > RaportointiAPIConstants.HAKUSANA_MAX_LENGTH))
+      Option.empty
+    else
+      Option.apply(parametri.get())
 
   def asValidRaportointitila(tila: Optional[String]): Option[RaportointiTila] =
     if(tila.isPresent)

--- a/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
+++ b/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
@@ -308,7 +308,7 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
       val sisalto_fi = if (kielet.contains(Kieli.FI)) sisalto_text else ""
       val sisalto_sv = if (kielet.contains(Kieli.SV)) sisalto_text else ""
       val sisalto_en = if (kielet.contains(Kieli.EN)) sisalto_text else ""
-      val sisalto_simple = if (kielet.isEmpty) sisalto_sanitized else ""
+      val sisalto_simple = if (kielet.isEmpty) sisalto_text else ""
 
       // tallennetaan viesti
       val viestiInsertAction =

--- a/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
+++ b/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
@@ -281,11 +281,17 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
     }
 
     val kayttooikeusRelatedInsertActions = kayttooikeusCreateActions.flatMap(oikeudet => {
+      // poistetaan otsikosta salaisuudet
+      val otsikko_sanitized = {
+        var o = otsikko
+        maskit.foreach(maski => o = o.replace(maski._1, ""))
+        o
+      }
       // generoidaan kielikohtaiset otsikot
-      val otsikko_fi = if (kielet.contains(Kieli.FI)) otsikko else ""
-      val otsikko_sv = if (kielet.contains(Kieli.SV)) otsikko else ""
-      val otsikko_en = if (kielet.contains(Kieli.EN)) otsikko else ""
-      val otsikko_simple = if (kielet.isEmpty) otsikko else ""
+      val otsikko_fi = if (kielet.contains(Kieli.FI)) otsikko_sanitized else ""
+      val otsikko_sv = if (kielet.contains(Kieli.SV)) otsikko_sanitized else ""
+      val otsikko_en = if (kielet.contains(Kieli.EN)) otsikko_sanitized else ""
+      val otsikko_simple = if (kielet.isEmpty) otsikko_sanitized else ""
 
       // poistetaan sisällöstä salaisuudet
       val sisalto_sanitized = {
@@ -897,10 +903,10 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
    * @param alkaen                    alkaen tästä vastaanottajasta
    * @param enintaan                  enintään näin monta vastaanottajaa
    * @param kayttooikeusTunnisteet    käyttäjän käyttöoikeuksien tunnisteet
-   * @param otsikkoHakuLauseke        lauseke jonka perusteella haetaan lähetyksiä perustuen jonkin sen viestin otsikkoon
-   * @param sisaltoHakuLauseke        lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin sisältöön
-   * @param vastaanottajaHakuLauseke  lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin vastaanottajaan
-   * @param metadataHakuLauseke       lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin metadataan
+   * @param otsikkoHakuLauseke        lauseke jonka perusteella haetaan vastaanottajia perustuen viestin otsikkoon
+   * @param sisaltoHakuLauseke        lauseke jonka perusteella haetaan vastaanottajia perustuen viestin sisältöön
+   * @param vastaanottajaHakuLauseke  lauseke jonka perusteella haetaan vastaanottajia
+   * @param metadataHakuLauseke       lauseke jonka perusteella haetaan vastaanottajia perustuen viestin metadataan
    * @param raportointiTila           vastaanottajan tila (kesken, valmis, virhe)
    *
    * @return                          tuple jossa maksimissaan enintään-parametrin määrä hakukriteereihin sopivia vastaanottajia

--- a/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
+++ b/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
@@ -308,7 +308,7 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
       val sisalto_fi = if (kielet.contains(Kieli.FI)) sisalto_text else ""
       val sisalto_sv = if (kielet.contains(Kieli.SV)) sisalto_text else ""
       val sisalto_en = if (kielet.contains(Kieli.EN)) sisalto_text else ""
-      val sisalto_simple = if (kielet.isEmpty) sisalto else ""
+      val sisalto_simple = if (kielet.isEmpty) sisalto_sanitized else ""
 
       // tallennetaan viesti
       val viestiInsertAction =
@@ -778,9 +778,9 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
         } concat sql""")""").as[Int]), DB_TIMEOUT).toSet).flatten.toSet
 
   def getViestienHakuLausekkeet(lahetysTunniste: Option[UUID], kayttooikeusTunnisteet: Option[Set[Int]],
-                                organisaatiot: Option[Set[String]], otsikkoHakuLauseke: Option[String],
-                                sisaltoHakuLauseke: Option[String], vastaanottajaHakuLauseke: Option[String],
-                                lahettajaHakuLauseke: Option[String], metadataHakuLausekkeet: Option[Map[String, Seq[String]]],
+                                organisaatiot: Option[Set[String]], sisaltoHakuLauseke: Option[String],
+                                vastaanottajaHakuLauseke: Option[String], lahettajaHakuLauseke: Option[String],
+                                metadataHakuLausekkeet: Option[Map[String, Seq[String]]],
                                 lahettavaPalveluHakuLauseke: Option[String]) =
     sql"""
         ((${kayttooikeusTunnisteet.isEmpty} OR
@@ -797,17 +797,18 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
         (${lahettajaHakuLauseke.isEmpty} OR
           haku_lahettaja = ${lahettajaHakuLauseke.getOrElse("")})
         AND
-        (${otsikkoHakuLauseke.isEmpty} OR haku_otsikko @@ (
-          websearch_to_tsquery('finnish', ${otsikkoHakuLauseke.getOrElse("")}) ||
-          websearch_to_tsquery('swedish', ${otsikkoHakuLauseke.getOrElse("")}) ||
-          websearch_to_tsquery('english', ${otsikkoHakuLauseke.getOrElse("")})
-        ))
-        AND
         (${sisaltoHakuLauseke.isEmpty} OR haku_sisalto @@ (
           websearch_to_tsquery('finnish', ${sisaltoHakuLauseke.getOrElse("")}) ||
           websearch_to_tsquery('swedish', ${sisaltoHakuLauseke.getOrElse("")}) ||
-          websearch_to_tsquery('english', ${sisaltoHakuLauseke.getOrElse("")})
+          websearch_to_tsquery('english', ${sisaltoHakuLauseke.getOrElse("")}) ||
+          websearch_to_tsquery('simple', ${sisaltoHakuLauseke.getOrElse("")})
+        ) OR (haku_otsikko @@ (
+          websearch_to_tsquery('finnish', ${sisaltoHakuLauseke.getOrElse("")}) ||
+          websearch_to_tsquery('swedish', ${sisaltoHakuLauseke.getOrElse("")}) ||
+          websearch_to_tsquery('english', ${sisaltoHakuLauseke.getOrElse("")}) ||
+          websearch_to_tsquery('simple', ${sisaltoHakuLauseke.getOrElse("")})
         ))
+        )
         AND
         (${metadataHakuLausekkeet.isEmpty} OR haku_metadata @> (
           ${metadataHakuLausekkeet.map(m => m.map((avain, arvot) => arvot.map(arvo => avain + ":" + arvo)).flatten.toSeq).getOrElse(Seq(""))}
@@ -832,8 +833,7 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
    * @param alkaen                    palautetaan lähetykset alkaen tämän lähetyksen jälkeen
    * @param enintaan                  palautetaan enintään näin monta lähetystä
    * @param kayttooikeusTunnisteet    käyttäjän käyttöoikeuksien tunnisteet (Option.Empty tarkoittaa pääkäyttäjää)
-   * @param otsikkoHakuLauseke        lauseke jonka perusteella haetaan lähetyksiä perustuen jonkin sen viestin otsikkoon
-   * @param sisaltoHakuLauseke        lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin sisältöön
+   * @param sisaltoHakuLauseke        lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin otsikkoon ja sisältöön
    * @param vastaanottajaHakuLauseke  lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin vastaanottajaan
    * @param lahettajaHakuLauseke      lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin lähettäjään
    * @param metadataHakuLauseke       lauseke jonka perusteella haetaan lähetyksia perustuen jonkin sen viestin metadataan
@@ -849,7 +849,6 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
                        enintaan: Int = 65535,
                        kayttooikeusTunnisteet: Option[Set[Int]] = Option.empty,
                        organisaatiot: Option[Set[String]] = Option.empty,
-                       otsikkoHakuLauseke: Option[String] = Option.empty,
                        sisaltoHakuLauseke: Option[String] = Option.empty,
                        vastaanottajaHakuLauseke: Option[String] = Option.empty,
                        lahettajaHakuLauseke: Option[String] = Option.empty,
@@ -872,7 +871,7 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
             WHERE
            """
           concat
-            getViestienHakuLausekkeet(Option.empty, kayttooikeusTunnisteet, organisaatiot, otsikkoHakuLauseke, sisaltoHakuLauseke,
+            getViestienHakuLausekkeet(Option.empty, kayttooikeusTunnisteet, organisaatiot, sisaltoHakuLauseke,
               vastaanottajaHakuLauseke, lahettajaHakuLauseke, metadataHakuLausekkeet, lahettavaPalveluHakuLauseke)
           concat
          sql"""
@@ -903,8 +902,7 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
    * @param alkaen                    alkaen tästä vastaanottajasta
    * @param enintaan                  enintään näin monta vastaanottajaa
    * @param kayttooikeusTunnisteet    käyttäjän käyttöoikeuksien tunnisteet
-   * @param otsikkoHakuLauseke        lauseke jonka perusteella haetaan vastaanottajia perustuen viestin otsikkoon
-   * @param sisaltoHakuLauseke        lauseke jonka perusteella haetaan vastaanottajia perustuen viestin sisältöön
+   * @param sisaltoHakuLauseke        lauseke jonka perusteella haetaan vastaanottajia perustuen viestin otsikkoon ja sisältöön
    * @param vastaanottajaHakuLauseke  lauseke jonka perusteella haetaan vastaanottajia
    * @param metadataHakuLauseke       lauseke jonka perusteella haetaan vastaanottajia perustuen viestin metadataan
    * @param raportointiTila           vastaanottajan tila (kesken, valmis, virhe)
@@ -918,7 +916,6 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
                            enintaan: Int = 65535,
                            kayttooikeusTunnisteet: Option[Set[Int]] = Option.empty,
                            organisaatiot: Option[Set[String]] = Option.empty,
-                           otsikkoHakuLauseke: Option[String] = Option.empty,
                            sisaltoHakuLauseke: Option[String] = Option.empty,
                            vastaanottajaHakuLauseke: Option[String] = Option.empty,
                            metadataHakuLausekkeet: Option[Map[String, Seq[String]]] = Option.empty,
@@ -929,7 +926,7 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
         FROM viestit JOIN vastaanottajat ON viestit.tunniste=vastaanottajat.viesti_tunniste
         WHERE
         """
-        concat getViestienHakuLausekkeet(Option.apply(lahetysTunniste), kayttooikeusTunnisteet, organisaatiot, otsikkoHakuLauseke,
+        concat getViestienHakuLausekkeet(Option.apply(lahetysTunniste), kayttooikeusTunnisteet, organisaatiot,
         sisaltoHakuLauseke, vastaanottajaHakuLauseke, Option.empty, metadataHakuLausekkeet, Option.empty) concat
         sql"""
         AND (${vastaanottajaHakuLauseke.isEmpty} OR vastaanottajat.sahkopostiosoite=${vastaanottajaHakuLauseke.getOrElse("")})

--- a/shared/src/test/scala/fi/oph/viestinvalitys/business/KantaOperaatiotTest.scala
+++ b/shared/src/test/scala/fi/oph/viestinvalitys/business/KantaOperaatiotTest.scala
@@ -1004,14 +1004,16 @@ class KantaOperaatiotTest {
 
   @Test def testSearchLahetyksetSanitized(): Unit =
     // luodaan viesti jossa salaisuus
-    val (viesti, _) = tallennaViesti(sisalto="Julkinen salainen", kielet = Set(Kieli.FI), maskit = Map(("salainen", Option.apply("*****"))))
+    val (viesti, _) = tallennaViesti(otsikko="Piilotettu avoin", sisalto="Julkinen salainen", kielet = Set(Kieli.FI), maskit = Map(("salainen", Option.apply("*****")), ("Piilotettu", Option.apply("*****"))))
     val lahetys = kantaOperaatiot.getLahetys(viesti.lahetysTunniste).get
 
     // salaisuuden perusteella ei voi hakea
     Assertions.assertEquals(Seq.empty, kantaOperaatiot.searchLahetykset(sisaltoHakuLauseke = Option.apply("salainen"))._1)
+    Assertions.assertEquals(Seq.empty, kantaOperaatiot.searchLahetykset(otsikkoHakuLauseke = Option.apply("Piilotettu"))._1)
 
     // julkisen osan perusteella voi hakea
     Assertions.assertEquals(Seq(lahetys), kantaOperaatiot.searchLahetykset(sisaltoHakuLauseke = Option.apply("julkinen"))._1)
+    Assertions.assertEquals(Seq(lahetys), kantaOperaatiot.searchLahetykset(otsikkoHakuLauseke = Option.apply("avoin"))._1)
 
   @Test def testSearchLahetyksetHtml(): Unit =
     val sisalto =

--- a/viestinvalitys-raportointi/src/app/Haku.tsx
+++ b/viestinvalitys-raportointi/src/app/Haku.tsx
@@ -70,7 +70,7 @@ export default function Haku() {
     if(term.length > 4 || term) {
       setHakusana(term)
     } else if (term.length == 0) {
-      setHakusana(null)
+      setHakusana(null) // kentän tyhjäys
     }
   }, 3000);
   const { t } = useTranslation();

--- a/viestinvalitys-raportointi/src/app/Haku.tsx
+++ b/viestinvalitys-raportointi/src/app/Haku.tsx
@@ -37,7 +37,7 @@ const HakukenttaSelect = ({
       <MenuItem value="lahettaja" key="lahettaja" disabled>
       {t('lahetykset.haku.lahettaja')}
       </MenuItem>
-      <MenuItem value="viesti" key="viesti" disabled>
+      <MenuItem value="viesti" key="viesti">
       {t('lahetykset.haku.otsikko-sisalto')}
       </MenuItem>
     </Select>
@@ -61,12 +61,17 @@ const HakukenttaInput = ({
 };
 
 export default function Haku() {
-  const [selectedHakukentta, setselectedHakukentta] = useQueryState("hakukentta", NUQS_DEFAULT_OPTIONS);
+  const [selectedHakukentta, setSelectedHakukentta] = useQueryState("hakukentta", NUQS_DEFAULT_OPTIONS);
   const [hakusana, setHakusana] = useQueryState("hakusana", NUQS_DEFAULT_OPTIONS);
 
   // päivitetään 3s viiveellä hakuparametrit
   const handleTypedSearch = useDebouncedCallback((term) => {
-    setHakusana(term)
+    // päivitetään kun minimipituus täyttyy
+    if(term.length > 4 || term) {
+      setHakusana(term)
+    } else if (term.length == 0) {
+      setHakusana(null)
+    }
   }, 3000);
   const { t } = useTranslation();
   return (
@@ -79,7 +84,7 @@ export default function Haku() {
       flexWrap="wrap"
       alignItems="flex-end"
     >
-      <HakukenttaInput value={selectedHakukentta ?? ''} onChange={(e) => setselectedHakukentta(e.target.value)}/>
+      <HakukenttaInput value={selectedHakukentta ?? ''} onChange={(e) => setSelectedHakukentta(e.target.value)}/>
       <FormControl
         sx={{
           flexGrow: 4,


### PR DESCRIPTION
- muutettu kantahakua niin että samalla hakusanalla kohdistetaan haku viestin otsikkoon ja sisältöön
- käliin ja raportointibackendiin lisäparametri