### PR TITLE
OK-436

### DIFF
--- a/cdk/bin/viestinvalityspalvelu.ts
+++ b/cdk/bin/viestinvalityspalvelu.ts
@@ -5,7 +5,7 @@ import { SovellusStack } from '../lib/sovellus-stack';
 import {PersistenssiStack} from "../lib/persistenssi-stack";
 import {LoadtestStack} from "../lib/loadtest-stack";
 import {MigraatioStack} from "../lib/migraatio-stack";
-import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
+import { AwsSolutionsChecks } from 'cdk-nag';
 
 const app = new cdk.App();
 const environmentName = app.node.tryGetContext("environment");

--- a/integraatio/src/test/scala/fi/oph/viestinvalitys/DevApp.scala
+++ b/integraatio/src/test/scala/fi/oph/viestinvalitys/DevApp.scala
@@ -20,13 +20,13 @@ object DevApp {
     System.setProperty("cas-service.service", "https://localhost:8443")
     System.setProperty("cas-service.sendRenew", "false")
     System.setProperty("cas-service.key", "viestinvalityspalvelu")
-    System.setProperty("web.url.cas", "https://virkailija.hahtuvaopintopolku.fi/cas")
+    System.setProperty("web.url.cas", "https://virkailija.testiopintopolku.fi/cas")
     if(!"localtest".equals(System.getProperty("ENVIRONMENT_NAME"))) {
       System.setProperty("ENVIRONMENT_NAME","local")
-      System.setProperty("DEV_OPINTOPOLKU_DOMAIN", "hahtuvaopintopolku.fi")
+      System.setProperty("DEV_OPINTOPOLKU_DOMAIN", "testiopintopolku.fi")
     }
 
-    System.setProperty("host.virkailija", "virkailija.hahtuvaopintopolku.fi")
+    System.setProperty("host.virkailija", "virkailija.testiopintopolku.fi")
     // swagger
     System.setProperty("springdoc.api-docs.path", "/openapi/v3/api-docs")
     System.setProperty("springdoc.swagger-ui.path", "/static/swagger-ui/index.html")

--- a/integraatio/src/test/scala/fi/oph/viestinvalitys/DevApp.scala
+++ b/integraatio/src/test/scala/fi/oph/viestinvalitys/DevApp.scala
@@ -20,13 +20,13 @@ object DevApp {
     System.setProperty("cas-service.service", "https://localhost:8443")
     System.setProperty("cas-service.sendRenew", "false")
     System.setProperty("cas-service.key", "viestinvalityspalvelu")
-    System.setProperty("web.url.cas", "https://virkailija.testiopintopolku.fi/cas")
+    System.setProperty("web.url.cas", "https://virkailija.hahtuvaopintopolku.fi/cas")
     if(!"localtest".equals(System.getProperty("ENVIRONMENT_NAME"))) {
       System.setProperty("ENVIRONMENT_NAME","local")
-      System.setProperty("DEV_OPINTOPOLKU_DOMAIN", "testiopintopolku.fi")
+      System.setProperty("DEV_OPINTOPOLKU_DOMAIN", "hahtuvaopintopolku.fi")
     }
 
-    System.setProperty("host.virkailija", "virkailija.testiopintopolku.fi")
+    System.setProperty("host.virkailija", "virkailija.hahtuvaopintopolku.fi")
     // swagger
     System.setProperty("springdoc.api-docs.path", "/openapi/v3/api-docs")
     System.setProperty("springdoc.swagger-ui.path", "/static/swagger-ui/index.html")

--- a/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/model/LahetyksetParamValidator.scala
+++ b/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/model/LahetyksetParamValidator.scala
@@ -17,7 +17,8 @@ case class LahetyksetParams(alkaen: Optional[String],
                             enintaan: Optional[String],
                             vastaanottajanEmail: Optional[String],
                             organisaatio: Optional[String],
-                            viesti: Optional[String])
+                            viesti: Optional[String],
+                            palvelu: Optional[String])
 object LahetyksetParamValidator {
 
   def validateAlkaenUUID(alkaen: Optional[String]): Set[String] =
@@ -69,7 +70,7 @@ object LahetyksetParamValidator {
       .flatMap(virheet =>
         if (hakusanaParam.isPresent && validatedHakusana.isEmpty) Left(virheet.incl(HAKUSANA_INVALID)) else Right(virheet))
       .fold(l => l, r => r)
-  
+
   def validateVastaanottajatParams(params: VastaanottajatParams): Seq[String] =
     Seq(
       validateLahetysTunniste(params.lahetysTunniste),
@@ -86,6 +87,7 @@ object LahetyksetParamValidator {
       validateEnintaan(params.enintaan, LAHETYKSET_ENINTAAN_MIN, LAHETYKSET_ENINTAAN_MAX, LAHETYKSET_ENINTAAN_INVALID),
       validateEmailParam(params.vastaanottajanEmail, VASTAANOTTAJA_INVALID),
       validateOrganisaatio(params.organisaatio),
-      validateHakusanaParam(params.viesti)
+      validateHakusanaParam(params.viesti),
+      validateHakusanaParam(params.palvelu)
     ).flatten
 }

--- a/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/LahetysResource.scala
+++ b/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/LahetysResource.scala
@@ -406,10 +406,12 @@ class LahetysResource {
       new ApiResponse(responseCode = "200", description = "Palauttaa listan palvelunimiä"),
     ))
   def getLahettavatPalvelut() = {
+    LOG.info("Haetaan lähettävät palvelut")
     val kantaOperaatiot = new KantaOperaatiot(DbUtil.database)
     try
       // suodatetaan pois swagger-esimerkkirivin palvelu
       val palvelut = kantaOperaatiot.getLahettavatPalvelut().filterNot(p => p.equals("Esimerkkipalvelu"))
+      LOG.info(s"Löytyi ${palvelut.size} palvelua")
       ResponseEntity.status(HttpStatus.OK).body(write[List[String]](palvelut))
     catch
       case e: Exception =>

--- a/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/RaportointiApiConstants.scala
+++ b/lambdat/raportointi/src/main/scala/fi/oph/viestinvalitys/raportointi/resource/RaportointiApiConstants.scala
@@ -24,6 +24,7 @@ object RaportointiAPIConstants {
   final val VASTAANOTTAJA_PARAM_NAME          = "vastaanottaja"
   final val ORGANISAATIO_PARAM_NAME           = "organisaatio"
   final val VIESTI_SISALTO_PARAM_NAME         = "viesti"
+  final val PALVELU_PARAM_NAME                = "palvelu"
 
   final val VIESTI_PATH                      = VERSIONED_RAPORTOINTI_API_PREFIX + "/viesti"
   final val VIESTITUNNISTE_PARAM_NAME         = "viestiTunniste"
@@ -36,6 +37,7 @@ object RaportointiAPIConstants {
   final val ORGANISAATIOT_PATH                = VERSIONED_RAPORTOINTI_API_PREFIX + "/organisaatiot"
   final val ORGANISAATIOT_OIKEUDET_PATH       = ORGANISAATIOT_PATH + "/oikeudet"
   final val OMAT_TIEDOT_PATH                  = VERSIONED_RAPORTOINTI_API_PREFIX + "/omattiedot"
+  final val PALVELUT_PATH                     = VERSIONED_RAPORTOINTI_API_PREFIX + "/palvelut"
 
   /**
    * Swagger-kuvauksiin liittyvät vakiot

--- a/shared/src/main/resources/flyway/V202409120000__create_lahettavapalvelu_index.sql
+++ b/shared/src/main/resources/flyway/V202409120000__create_lahettavapalvelu_index.sql
@@ -1,0 +1,2 @@
+-- lista lähettävistä palveluista muodostetaan toistaiseksi lähetyksien tiedoista, palvelu cachettaa
+create index lahetykset_lahettavapalvelu_index on lahetykset (lahettavapalvelu asc);

--- a/shared/src/main/resources/flyway/V202409120000__create_lahettavapalvelu_index.sql
+++ b/shared/src/main/resources/flyway/V202409120000__create_lahettavapalvelu_index.sql
@@ -1,2 +1,2 @@
 -- lista lähettävistä palveluista muodostetaan toistaiseksi lähetyksien tiedoista, palvelu cachettaa
-create index lahetykset_lahettavapalvelu_index on lahetykset (lahettavapalvelu asc);
+CREATE INDEX IF NOT EXISTS lahetykset_lahettavapalvelu_index on lahetykset (lahettavapalvelu asc);

--- a/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
+++ b/shared/src/main/scala/fi/oph/viestinvalitys/business/KantaOperaatiot.scala
@@ -1116,4 +1116,19 @@ class KantaOperaatiot(db: JdbcBackend.JdbcDatabaseDef) {
             maskit = maskit.get(tunniste).getOrElse(Map.empty),
             omistaja = omistaja,
             prioriteetti = Prioriteetti.valueOf(prioriteetti))).headOption
+
+  /**
+   * Hakee listan lähettävistä palveluista
+   *
+   * @return lista lähetyksille tallennetuista lähettävistä palveluista
+   */
+  def getLahettavatPalvelut(): List[String] =
+
+    val lahettavatPalvelutQuery = sql"""
+       SELECT DISTINCT lahettavapalvelu
+       FROM lahetykset
+       ORDER BY lahettavapalvelu ASC
+     """.as[String]
+    Await.result(db.run(lahettavatPalvelutQuery), DB_TIMEOUT).toList
+
 }

--- a/shared/src/test/scala/fi/oph/viestinvalitys/business/KantaOperaatiotTest.scala
+++ b/shared/src/test/scala/fi/oph/viestinvalitys/business/KantaOperaatiotTest.scala
@@ -1286,4 +1286,18 @@ class KantaOperaatiotTest {
       kantaOperaatiot.getRaportointiViestiTunnisteella(viesti.tunniste, kayttajanKayttooikeudet).get)
     // ei käyttöoikeuksia
     Assertions.assertEquals(Option.empty, kantaOperaatiot.getRaportointiViestiTunnisteella(viesti2.tunniste, kayttajanKayttooikeudet))
+
+  /**
+   * Testataan lähettävien palvelujen listan haku
+   */
+  @Test def testGetLahettavatPalvelut(): Unit =
+    // lähetyksiä eri palveluilla
+    val lahetys = this.tallennaLahetys(lahettavaPalvelu = "hakemuspalvelu")
+    val lahetys2 = this.tallennaLahetys(lahettavaPalvelu = "osoitepalvelu")
+    val lahetys3 = this.tallennaLahetys(lahettavaPalvelu = "jokupalvelu")
+    // sama palvelu
+    val lahetys4 = this.tallennaLahetys(lahettavaPalvelu = "hakemuspalvelu")
+    // Esimerkkipalvelu on alustettuna kantaan
+    Assertions.assertEquals(4, kantaOperaatiot.getLahettavatPalvelut().size)
+    Assertions.assertEquals(List("Esimerkkipalvelu", "hakemuspalvelu", "jokupalvelu", "osoitepalvelu"), kantaOperaatiot.getLahettavatPalvelut())
 }

--- a/viestinvalitys-raportointi/package-lock.json
+++ b/viestinvalitys-raportointi/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/material-nextjs": "^5.15.11",
         "@mui/x-data-grid": "^6.18.7",
         "@mui/x-tree-view": "^6.17.0",
-        "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.2",
+        "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.3",
         "@tanstack/react-query": "^5.51.5",
         "@tanstack/react-query-devtools": "^5.51.5",
         "dompurify": "^3.0.11",

--- a/viestinvalitys-raportointi/package-lock.json
+++ b/viestinvalitys-raportointi/package-lock.json
@@ -18,6 +18,7 @@
         "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.3",
         "@tanstack/react-query": "^5.51.5",
         "@tanstack/react-query-devtools": "^5.51.5",
+        "date-fns-tz": "^3.1.3",
         "dompurify": "^3.0.11",
         "i18next": "^23.11.5",
         "i18next-chained-backend": "^4.6.2",
@@ -1780,9 +1781,8 @@
       }
     },
     "node_modules/@opetushallitus/oph-design-system": {
-      "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/opetushallitus/oph-design-system.git#56838f9afdcccea63f91652332c484e133e09f69",
-      "license": "EUPL-1.2",
+      "version": "0.0.3",
+      "resolved": "git+ssh://git@github.com/opetushallitus/oph-design-system.git#4033d6e687bbda8706bdd3eed61a9cd959c4e950",
       "peerDependencies": {
         "@mui/material": "^5",
         "next": "^14",
@@ -3947,6 +3947,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.1.3.tgz",
+      "integrity": "sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0"
       }
     },
     "node_modules/debug": {

--- a/viestinvalitys-raportointi/package.json
+++ b/viestinvalitys-raportointi/package.json
@@ -20,6 +20,7 @@
     "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.3",
     "@tanstack/react-query": "^5.51.5",
     "@tanstack/react-query-devtools": "^5.51.5",
+    "date-fns-tz": "^3.1.3",
     "dompurify": "^3.0.11",
     "i18next": "^23.11.5",
     "i18next-chained-backend": "^4.6.2",

--- a/viestinvalitys-raportointi/package.json
+++ b/viestinvalitys-raportointi/package.json
@@ -17,7 +17,7 @@
     "@mui/material-nextjs": "^5.15.11",
     "@mui/x-data-grid": "^6.18.7",
     "@mui/x-tree-view": "^6.17.0",
-    "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.2",
+    "@opetushallitus/oph-design-system": "github:opetushallitus/oph-design-system#v0.0.3",
     "@tanstack/react-query": "^5.51.5",
     "@tanstack/react-query-devtools": "^5.51.5",
     "dompurify": "^3.0.11",

--- a/viestinvalitys-raportointi/src/app/Haku.tsx
+++ b/viestinvalitys-raportointi/src/app/Haku.tsx
@@ -60,7 +60,7 @@ const HakukenttaInput = ({
   );
 };
 
-export default function Haku() {
+export default function Haku({lahettavatPalvelut}: {lahettavatPalvelut: string[]}) {
   const [selectedHakukentta, setSelectedHakukentta] = useQueryState(
     'hakukentta',
     NUQS_DEFAULT_OPTIONS,
@@ -132,8 +132,8 @@ export default function Haku() {
       >
         <LahettavaPalveluInput
           value={palvelu}
-          onChange={(e) => setPalvelu(e.target.value)}
-        />
+          onChange={(e) => setPalvelu(e.target.value)} 
+          palvelut={lahettavatPalvelut} />
       </Box>
     </Box>
   );

--- a/viestinvalitys-raportointi/src/app/Haku.tsx
+++ b/viestinvalitys-raportointi/src/app/Haku.tsx
@@ -14,6 +14,7 @@ import { useQueryState } from 'nuqs';
 import { Search } from '@mui/icons-material';
 import { NUQS_DEFAULT_OPTIONS } from './lib/constants';
 import { useTranslation } from './i18n/clientLocalization';
+import { LahettavaPalveluInput } from './components/LahettavaPalveluInput';
 
 const HakukenttaSelect = ({
   value: selectedHakukentta,
@@ -35,10 +36,10 @@ const HakukenttaSelect = ({
         {t('lahetykset.haku.vastaanottaja')}
       </MenuItem>
       <MenuItem value="lahettaja" key="lahettaja" disabled>
-      {t('lahetykset.haku.lahettaja')}
+        {t('lahetykset.haku.lahettaja')}
       </MenuItem>
       <MenuItem value="viesti" key="viesti">
-      {t('lahetykset.haku.otsikko-sisalto')}
+        {t('lahetykset.haku.otsikko-sisalto')}
       </MenuItem>
     </Select>
   );
@@ -54,61 +55,89 @@ const HakukenttaInput = ({
   const { t } = useTranslation();
   return (
     <FormControl sx={{ flex: '1 0 180px', textAlign: 'left' }}>
-      <FormLabel id="hakukentta-select-label">{t('lahetykset.haku.mista-haetaan')}</FormLabel>
+      <FormLabel id="hakukentta-select-label">
+        {t('lahetykset.haku.mista-haetaan')}
+      </FormLabel>
       <HakukenttaSelect value={value} onChange={onChange} />
     </FormControl>
   );
 };
 
 export default function Haku() {
-  const [selectedHakukentta, setSelectedHakukentta] = useQueryState("hakukentta", NUQS_DEFAULT_OPTIONS);
-  const [hakusana, setHakusana] = useQueryState("hakusana", NUQS_DEFAULT_OPTIONS);
+  const [selectedHakukentta, setSelectedHakukentta] = useQueryState(
+    'hakukentta',
+    NUQS_DEFAULT_OPTIONS,
+  );
+  const [hakusana, setHakusana] = useQueryState(
+    'hakusana',
+    NUQS_DEFAULT_OPTIONS,
+  );
+  const [palvelu, setPalvelu] = useQueryState(
+    'palvelu',
+    NUQS_DEFAULT_OPTIONS,
+  );
 
   // päivitetään 3s viiveellä hakuparametrit
   const handleTypedSearch = useDebouncedCallback((term) => {
     // päivitetään kun minimipituus täyttyy
-    if(term.length > 4 || term) {
-      setHakusana(term)
+    if (term.length > 4 || term) {
+      setHakusana(term);
     } else if (term.length == 0) {
-      setHakusana(null) // kentän tyhjäys
+      setHakusana(null); // kentän tyhjäys
     }
   }, 3000);
   const { t } = useTranslation();
   return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      justifyContent="stretch"
-      gap={2}
-      marginBottom={2}
-      flexWrap="wrap"
-      alignItems="flex-end"
-    >
-      <HakukenttaInput value={selectedHakukentta ?? ''} onChange={(e) => setSelectedHakukentta(e.target.value)}/>
-      <FormControl
-        sx={{
-          flexGrow: 4,
-          minWidth: '180px',
-          textAlign: 'left',
-        }}
+    <Box>
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="stretch"
+        gap={2}
+        marginBottom={2}
+        flexWrap="wrap"
+        alignItems="flex-end"
       >
-        <FormLabel htmlFor="haku-search">{t('lahetykset.hae')}</FormLabel>
-        <OutlinedInput
-          id="haku-search"
-          name="haku-search"
-          defaultValue={hakusana}
-          onChange={(e) => {
-            handleTypedSearch(e.target.value);
-          }}
-          autoFocus={true}
-          type="text"
-          endAdornment={
-            <InputAdornment position="end">
-              <Search />
-            </InputAdornment>
-          }
+        <HakukenttaInput
+          value={selectedHakukentta ?? ''}
+          onChange={(e) => setSelectedHakukentta(e.target.value)}
         />
-      </FormControl>
+        <FormControl
+          sx={{
+            flexGrow: 4,
+            minWidth: '180px',
+            textAlign: 'left',
+          }}
+        >
+          <FormLabel htmlFor="haku-search">{t('lahetykset.hae')}</FormLabel>
+          <OutlinedInput
+            id="haku-search"
+            name="haku-search"
+            defaultValue={hakusana}
+            onChange={(e) => {
+              handleTypedSearch(e.target.value);
+            }}
+            autoFocus={true}
+            type="text"
+            endAdornment={
+              <InputAdornment position="end">
+                <Search />
+              </InputAdornment>
+            }
+          />
+        </FormControl>
+      </Box>
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="stretch"
+        gap={2}
+        marginBottom={2}
+        flexWrap="wrap"
+        alignItems="flex-end"
+      >
+        <LahettavaPalveluInput value={palvelu} onChange={(e) => setPalvelu(e.target.value)} />
+      </Box>
     </Box>
   );
 }

--- a/viestinvalitys-raportointi/src/app/Haku.tsx
+++ b/viestinvalitys-raportointi/src/app/Haku.tsx
@@ -1,12 +1,8 @@
 'use client';
 import {
   Box,
-  FormControl,
-  FormLabel,
   InputAdornment,
-  MenuItem,
   OutlinedInput,
-  Select,
   SelectChangeEvent,
 } from '@mui/material';
 import { useDebouncedCallback } from 'use-debounce';
@@ -15,33 +11,33 @@ import { Search } from '@mui/icons-material';
 import { NUQS_DEFAULT_OPTIONS } from './lib/constants';
 import { useTranslation } from './i18n/clientLocalization';
 import { LahettavaPalveluInput } from './components/LahettavaPalveluInput';
+import { OphFormControl } from './components/OphFormControl';
+import { OphSelect } from '@opetushallitus/oph-design-system';
 
 const HakukenttaSelect = ({
+  labelId,
   value: selectedHakukentta,
   onChange,
 }: {
+  labelId: string;
   value: string;
   onChange: (e: SelectChangeEvent) => void;
 }) => {
   const { t } = useTranslation();
   return (
-    <Select
-      labelId="hakukentta-select-label"
-      name="hakukentta-select"
+    <OphSelect
+      labelId={labelId}
+      id="hakukentta-select"
       value={selectedHakukentta ?? ''}
       onChange={onChange}
+      options={[
+        { value: 'vastaanottaja', label: t('lahetykset.haku.vastaanottaja') },
+        { value: 'lahettaja', label: t('lahetykset.haku.lahettaja') },
+        { value: 'viesti', label: t('lahetykset.haku.otsikko-sisalto') },
+      ]}
+      clearable
       displayEmpty={true}
-    >
-      <MenuItem value="vastaanottaja" key="vastaanottaja">
-        {t('lahetykset.haku.vastaanottaja')}
-      </MenuItem>
-      <MenuItem value="lahettaja" key="lahettaja" disabled>
-        {t('lahetykset.haku.lahettaja')}
-      </MenuItem>
-      <MenuItem value="viesti" key="viesti">
-        {t('lahetykset.haku.otsikko-sisalto')}
-      </MenuItem>
-    </Select>
+    />
   );
 };
 
@@ -54,12 +50,13 @@ const HakukenttaInput = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <FormControl sx={{ flex: '1 0 180px', textAlign: 'left' }}>
-      <FormLabel id="hakukentta-select-label">
-        {t('lahetykset.haku.mista-haetaan')}
-      </FormLabel>
-      <HakukenttaSelect value={value} onChange={onChange} />
-    </FormControl>
+    <OphFormControl
+      label={t('lahetykset.haku.mista-haetaan')}
+      sx={{ flex: '1 0 180px', textAlign: 'left' }}
+      renderInput={({ labelId }) => (
+        <HakukenttaSelect value={value} onChange={onChange} labelId={labelId} />
+      )}
+    />
   );
 };
 
@@ -72,10 +69,7 @@ export default function Haku() {
     'hakusana',
     NUQS_DEFAULT_OPTIONS,
   );
-  const [palvelu, setPalvelu] = useQueryState(
-    'palvelu',
-    NUQS_DEFAULT_OPTIONS,
-  );
+  const [palvelu, setPalvelu] = useQueryState('palvelu', NUQS_DEFAULT_OPTIONS);
 
   // päivitetään 3s viiveellä hakuparametrit
   const handleTypedSearch = useDebouncedCallback((term) => {
@@ -102,30 +96,30 @@ export default function Haku() {
           value={selectedHakukentta ?? ''}
           onChange={(e) => setSelectedHakukentta(e.target.value)}
         />
-        <FormControl
-          sx={{
-            flexGrow: 4,
-            minWidth: '180px',
-            textAlign: 'left',
+        <OphFormControl
+          label={t('lahetykset.hae')}
+          sx={{ flexGrow: 4, minWidth: '180px', textAlign: 'left' }}
+          renderInput={({ labelId }) => {
+            return (
+              <OutlinedInput
+                id="haku-search"
+                name="haku-search"
+                inputProps={{ 'aria-labelledby': labelId }}
+                defaultValue={hakusana}
+                onChange={(e) => {
+                  handleTypedSearch(e.target.value);
+                }}
+                autoFocus={true}
+                type="text"
+                endAdornment={
+                  <InputAdornment position="end">
+                    <Search />
+                  </InputAdornment>
+                }
+              />
+            );
           }}
-        >
-          <FormLabel htmlFor="haku-search">{t('lahetykset.hae')}</FormLabel>
-          <OutlinedInput
-            id="haku-search"
-            name="haku-search"
-            defaultValue={hakusana}
-            onChange={(e) => {
-              handleTypedSearch(e.target.value);
-            }}
-            autoFocus={true}
-            type="text"
-            endAdornment={
-              <InputAdornment position="end">
-                <Search />
-              </InputAdornment>
-            }
-          />
-        </FormControl>
+        />
       </Box>
       <Box
         display="flex"
@@ -136,7 +130,10 @@ export default function Haku() {
         flexWrap="wrap"
         alignItems="flex-end"
       >
-        <LahettavaPalveluInput value={palvelu} onChange={(e) => setPalvelu(e.target.value)} />
+        <LahettavaPalveluInput
+          value={palvelu}
+          onChange={(e) => setPalvelu(e.target.value)}
+        />
       </Box>
     </Box>
   );

--- a/viestinvalitys-raportointi/src/app/components/ClientSpinner.tsx
+++ b/viestinvalitys-raportointi/src/app/components/ClientSpinner.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { CircularProgress, CircularProgressProps } from '@mui/material';
+import { useTranslation } from '../i18n/clientLocalization';
+
+export const ClientSpinner = (props: CircularProgressProps) => {
+  const { t } = useTranslation();
+  return <CircularProgress aria-label={t('yleinen.ladataan')} {...props} />;
+};

--- a/viestinvalitys-raportointi/src/app/components/GreyDivider.tsx
+++ b/viestinvalitys-raportointi/src/app/components/GreyDivider.tsx
@@ -1,10 +1,10 @@
 'use client';
 import { Divider } from "@mui/material";
-import { colors } from "../theme";
+import { ophColors } from "@opetushallitus/oph-design-system";
 
 export const GreyDivider = () => {
     return (
-    <Divider variant="middle" sx={{ color: colors.grey400, height: '2px'}} aria-hidden="true" />
+    <Divider variant="middle" sx={{ color: ophColors.grey400, height: '2px'}} aria-hidden="true" />
     );
   };
 

--- a/viestinvalitys-raportointi/src/app/components/HomeIconLink.tsx
+++ b/viestinvalitys-raportointi/src/app/components/HomeIconLink.tsx
@@ -1,18 +1,18 @@
 'use client';
 import { HomeOutlined } from '@mui/icons-material';
-import { Button } from '@opetushallitus/oph-design-system';
+import { OphButton } from '@opetushallitus/oph-design-system';
 import { useTranslation } from '../i18n/clientLocalization';
 
 const HomeIconLink = () => {
   const { t } = useTranslation();
   return (
-    <Button
+    <OphButton
       startIcon={<HomeOutlined />}
       aria-label={t('yleinen.palaa.etusivulle')}
       href="/"
       sx={{ border: '1px solid', borderRadius: '5px', width: 30, height: 30 }}
     >
-    </Button>
+    </OphButton>
   );
 };
 

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -42,15 +42,9 @@ export const LahettavaPalveluInput = ({
 }) => {
   const { t } = useTranslation();
 
-  const doFetchLahettavatPalvelut = async (): Promise<string[]> => {
-    console.info('doFetchLahettavatPalvelut');
-    const response = await fetchLahettavatPalvelut();
-    return response;
-  };
-
   const { data, isLoading } = useQuery({
-    queryKey: ['fetchLahettavatPalvelut'],
-    queryFn: () => doFetchLahettavatPalvelut(),
+    queryKey: ['palvelut'],
+    queryFn: () => fetchLahettavatPalvelut(),
   });
   if (isLoading) {
     return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -43,7 +43,9 @@ export const LahettavaPalveluInput = ({
   const { t } = useTranslation();
 
   const doFetchPalvelut = async (): Promise<string[]> => {
-    const response = await await fetchLahettavatPalvelut();
+    console.log('doFetchPalvelut')
+    const response = await fetchLahettavatPalvelut();
+    console.log(response)
     return response ?? [];
   };
 

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -2,9 +2,7 @@
 import { OphFormControl } from './OphFormControl';
 import { useTranslation } from '../i18n/clientLocalization';
 import { SelectChangeEvent } from '@mui/material';
-import { OphSelect, OphTypography } from '@opetushallitus/oph-design-system';
-import { useQuery } from '@tanstack/react-query';
-import { fetchLahettavatPalvelut } from '../lib/data';
+import { OphSelect } from '@opetushallitus/oph-design-system';
 
 const LahettavaPalveluSelect = ({
   labelId,
@@ -36,27 +34,14 @@ const LahettavaPalveluSelect = ({
 export const LahettavaPalveluInput = ({
   value,
   onChange,
+  palvelut
 }: {
   value: string;
   onChange: (e: SelectChangeEvent) => void;
+  palvelut: string[];
 }) => {
   const { t } = useTranslation();
 
-  const doFetchPalvelut = async (): Promise<string[]> => {
-    console.log('doFetchPalvelut')
-    const response = await fetchLahettavatPalvelut();
-    console.log(response)
-    return response ?? [];
-  };
-
-  const { data, isLoading } = useQuery({
-    queryKey: ['palvelut'],
-    queryFn: () => doFetchPalvelut(),
-    refetchOnMount: true
-  });
-  if (isLoading) {
-    return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;
-  }
   return (
     <OphFormControl
       label={t('lahetykset.haku.lahettava-palvelu')}
@@ -65,7 +50,7 @@ export const LahettavaPalveluInput = ({
         <LahettavaPalveluSelect
           labelId={labelId}
           value={value}
-          options={data ?? []}
+          options={palvelut}
           onChange={onChange}
         />
       )}

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -45,7 +45,6 @@ export const LahettavaPalveluInput = ({
   const doFetchLahettavatPalvelut = async (): Promise<string[]> => {
     console.info('doFetchLahettavatPalvelut');
     const response = await fetchLahettavatPalvelut();
-    console.info(response)
     return response;
   };
 

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -43,7 +43,9 @@ export const LahettavaPalveluInput = ({
   const { t } = useTranslation();
 
   const doFetchLahettavatPalvelut = async (): Promise<string[]> => {
+    console.info('doFetchLahettavatPalvelut');
     const response = await fetchLahettavatPalvelut();
+    console.info(response)
     return response;
   };
 

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { OphFormControl } from './OphFormControl';
+import { useTranslation } from '../i18n/clientLocalization';
+import {
+  SelectChangeEvent,
+} from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { fetchLahettavatPalvelut } from '../lib/data';
+import { OphSelect, OphTypography } from '@opetushallitus/oph-design-system';
+
+const LahettavaPalveluSelect = ({
+  labelId,
+  value: selectedPalvelu,
+  options,
+  onChange,
+}: {
+  labelId: string;
+  value: string;
+  options: string[];
+  onChange: (e: SelectChangeEvent) => void;
+}) => {
+  const palveluOptions = options.map((palvelu) => {
+    return { value: palvelu, label: palvelu };
+  });
+
+  return (
+    <OphSelect
+      labelId={labelId}
+      id="palvelu-select"
+      value={selectedPalvelu ?? ''}
+      onChange={onChange}
+      options={palveluOptions}
+      clearable
+    />
+  );
+};
+
+export const LahettavaPalveluInput = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (e: SelectChangeEvent) => void;
+}) => {
+  const { t } = useTranslation();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['fetchLahettavatPalvelut'],
+    queryFn: () => fetchLahettavatPalvelut(),
+  });
+  if (isLoading) {
+    return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;
+  }
+  return (
+    <OphFormControl
+      label={t('lahetykset.haku.lahettava-palvelu')}
+      sx={{ flex: '1 0 180px', textAlign: 'left' }}
+      renderInput={({ labelId }) => (
+          <LahettavaPalveluSelect
+            labelId={labelId}
+            value={value}
+            options={data ?? []}
+            onChange={onChange}
+          />
+      )}
+    />
+  );
+};

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -49,7 +49,8 @@ export const LahettavaPalveluInput = ({
 
   const { data, isLoading } = useQuery({
     queryKey: ['palvelut'],
-    queryFn: () => doFetchPalvelut()
+    queryFn: () => doFetchPalvelut(),
+    refetchOnMount: true
   });
   if (isLoading) {
     return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -2,9 +2,9 @@
 import { OphFormControl } from './OphFormControl';
 import { useTranslation } from '../i18n/clientLocalization';
 import { SelectChangeEvent } from '@mui/material';
+import { OphSelect, OphTypography } from '@opetushallitus/oph-design-system';
 import { useQuery } from '@tanstack/react-query';
 import { fetchLahettavatPalvelut } from '../lib/data';
-import { OphSelect, OphTypography } from '@opetushallitus/oph-design-system';
 
 const LahettavaPalveluSelect = ({
   labelId,
@@ -42,9 +42,14 @@ export const LahettavaPalveluInput = ({
 }) => {
   const { t } = useTranslation();
 
+  const doFetchPalvelut = async (): Promise<string[]> => {
+    const response = await await fetchLahettavatPalvelut();
+    return response ?? [];
+  };
+
   const { data, isLoading } = useQuery({
     queryKey: ['palvelut'],
-    queryFn: () => fetchLahettavatPalvelut(),
+    queryFn: () => doFetchPalvelut()
   });
   if (isLoading) {
     return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;

--- a/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahettavaPalveluInput.tsx
@@ -1,9 +1,7 @@
 'use client';
 import { OphFormControl } from './OphFormControl';
 import { useTranslation } from '../i18n/clientLocalization';
-import {
-  SelectChangeEvent,
-} from '@mui/material';
+import { SelectChangeEvent } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { fetchLahettavatPalvelut } from '../lib/data';
 import { OphSelect, OphTypography } from '@opetushallitus/oph-design-system';
@@ -43,10 +41,15 @@ export const LahettavaPalveluInput = ({
   onChange: (e: SelectChangeEvent) => void;
 }) => {
   const { t } = useTranslation();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data, isLoading, error, refetch } = useQuery({
+
+  const doFetchLahettavatPalvelut = async (): Promise<string[]> => {
+    const response = await fetchLahettavatPalvelut();
+    return response;
+  };
+
+  const { data, isLoading } = useQuery({
     queryKey: ['fetchLahettavatPalvelut'],
-    queryFn: () => fetchLahettavatPalvelut(),
+    queryFn: () => doFetchLahettavatPalvelut(),
   });
   if (isLoading) {
     return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;
@@ -56,12 +59,12 @@ export const LahettavaPalveluInput = ({
       label={t('lahetykset.haku.lahettava-palvelu')}
       sx={{ flex: '1 0 180px', textAlign: 'left' }}
       renderInput={({ labelId }) => (
-          <LahettavaPalveluSelect
-            labelId={labelId}
-            value={value}
-            options={data ?? []}
-            onChange={onChange}
-          />
+        <LahettavaPalveluSelect
+          labelId={labelId}
+          value={value}
+          options={data ?? []}
+          onChange={onChange}
+        />
       )}
     />
   );

--- a/viestinvalitys-raportointi/src/app/components/LahetysStatus.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LahetysStatus.tsx
@@ -3,17 +3,17 @@ import { CheckCircle, Error, Warning, WatchLater } from '@mui/icons-material';
 import { Status, LahetyksenVastaanottoTila } from '../lib/types';
 import { getLahetyksenVastaanottajia, getLahetysStatus, getVastaanottajatPerStatus } from '../lib/util';
 import { Box } from '@mui/material';
-import { aliasColors, colors } from '../theme';
 import { useTranslation } from '../i18n/clientLocalization';
+import { ophColors } from '@opetushallitus/oph-design-system';
 
 export const StatusIcon = ({ status }: { status: string }) => {
   switch (status) {
     case Status.EPAONNISTUI:
-      return <Error sx={{ color: aliasColors.error }} />;
+      return <Error sx={{ color: ophColors.alias.error }} />;
     case Status.KESKEN:
-      return <WatchLater sx={{ color: colors.yellow1 }} />;
+      return <WatchLater sx={{ color: ophColors.yellow1 }} />;
     case Status.ONNISTUI:
-      return <CheckCircle sx={{ color: aliasColors.success }} />;
+      return <CheckCircle sx={{ color: ophColors.alias.success }} />;
     default:
       return <Warning />;
   }

--- a/viestinvalitys-raportointi/src/app/components/LocalDateTime.tsx
+++ b/viestinvalitys-raportointi/src/app/components/LocalDateTime.tsx
@@ -1,19 +1,34 @@
 'use client';
+import { useEffect, useState } from "react";
+import { format, toZonedTime } from 'date-fns-tz';
+import { OphTypography } from "@opetushallitus/oph-design-system";
 
-import { Suspense } from 'react';
-import { useHydration } from '../hooks/useHydration';
+// päivämääräformatoinnin hydraatio-ongelman taklaus 
+// ks. https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only
+export default function LocalDateTime({date}: {date: string}) {
+  const [isClient, setIsClient] = useState(false);
 
-// pieni kikkailu SSR hydration-ongelman välttämiseksi
-// ks. https://francoisbest.com/posts/2023/displaying-local-times-in-nextjs
-const LocalDateTime = ({ date }: { date: string }) => {
-  const hydrated = useHydration();
-  return (
-    <Suspense key={hydrated ? 'local' : 'utc'}>
-      <time dateTime={new Date(date).toISOString()}>
-        {new Date(date).toLocaleString()}
-        {hydrated ? '' : ' (UTC)'}
-      </time>
-    </Suspense>
-  );
-};
-export default LocalDateTime;
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  return <OphTypography>{isClient ? toFormattedDateTimeString(date) : ''}</OphTypography>;
+}
+
+function toFormattedDateTimeString(value: string): string {
+  try {
+    const zonedDate = toZonedTime(new Date(value), 'Europe/Helsinki');
+    return format(zonedDate, 'd.M.yyyy HH:mm', {
+      timeZone: 'Europe/Helsinki',
+    });
+  } catch (error) {
+    console.warn(
+      'Caught error when trying to format date, returning empty string',
+    );
+    return '';
+  }
+}
+
+
+
+

--- a/viestinvalitys-raportointi/src/app/components/MainContainer.tsx
+++ b/viestinvalitys-raportointi/src/app/components/MainContainer.tsx
@@ -1,13 +1,16 @@
 'use client';
 import { styled } from '@mui/material/styles';
 import { Box } from '@mui/material';
-import { DEFAULT_BOX_BORDER, colors, withDefaultProps } from '@/app/theme';
+import { ophColors } from '@opetushallitus/oph-design-system';
+import { withDefaultProps } from '../theme';
+
+export const DEFAULT_BOX_BORDER = `2px solid ${ophColors.grey100}`;
 
 export const MainContainer = withDefaultProps(
     styled(Box)(({ theme }) => ({
       padding: theme.spacing(4),
       border: DEFAULT_BOX_BORDER,
-      backgroundColor: colors.white,
+      backgroundColor: ophColors.white,
     })),
     {
       component: 'main',

--- a/viestinvalitys-raportointi/src/app/components/NavAppBar.tsx
+++ b/viestinvalitys-raportointi/src/app/components/NavAppBar.tsx
@@ -4,9 +4,8 @@ import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import OrganisaatioSelect from './OrganisaatioSelect';
 import { Suspense } from 'react';
 import Loading from './Loading';
-import { colors } from '../theme';
 import { PageContent } from './PageContent';
-import { Typography } from '@opetushallitus/oph-design-system';
+import { ophColors, OphTypography } from '@opetushallitus/oph-design-system';
 import { usePathname } from 'next/navigation';
 import { useTranslation } from '../i18n/clientLocalization';
 
@@ -18,9 +17,9 @@ export default function Header() {
     <header
       style={{
         position: 'relative',
-        backgroundColor: colors.white,
+        backgroundColor: ophColors.white,
         width: '100%',
-        border: `2px solid ${colors.grey100}`,
+        border: `2px solid ${ophColors.grey100}`,
       }}
     >
       <PageContent
@@ -32,14 +31,14 @@ export default function Header() {
         }}
       >
         {isHome ? (
-          <Typography variant="h1">{t('lahetykset.otsikko')}</Typography>
+          <OphTypography variant="h1">{t('lahetykset.otsikko')}</OphTypography>
         ) : (
           <>
             <HomeIconLink />
-            <Typography variant="h2">
-              <NavigateNextIcon sx={{ color: colors.grey500 }} />
+            <OphTypography variant="h2">
+              <NavigateNextIcon sx={{ color: ophColors.grey500 }} />
               {t('navigointi.lahetykset')}
-            </Typography>
+            </OphTypography>
           </>
         )}
         <Suspense fallback={<Loading />}>

--- a/viestinvalitys-raportointi/src/app/components/OphFormControl.tsx
+++ b/viestinvalitys-raportointi/src/app/components/OphFormControl.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { FormControl, FormControlProps, FormHelperText, FormLabel, styled } from "@mui/material";
+import { useId } from "react";
+
+const StyledFormHelperText = styled(FormHelperText)(({ theme }) => ({
+    margin: theme.spacing(0.5, 0),
+  }));
+  
+  const EMPTY_ARRAY: Array<unknown> = [];
+
+  export const OphFormControl = ({
+    label,
+    renderInput,
+    helperText,
+    errorMessages = EMPTY_ARRAY as Array<string>,
+    ...props
+  }: Omit<FormControlProps, 'children'> & {
+    label: string;
+    helperText?: string;
+    errorMessages?: Array<string>;
+    renderInput: (props: { labelId: string }) => React.ReactNode;
+  }) => {
+    const id = useId();
+    const labelId = `OphFormControl-${id}-label`;
+    return (
+      <FormControl {...props}>
+        <FormLabel id={labelId}>{label}</FormLabel>
+        {helperText && (
+          <StyledFormHelperText error={false}>{helperText}</StyledFormHelperText>
+        )}
+        {renderInput({ labelId })}
+        {errorMessages.map((message, index) => (
+          <StyledFormHelperText error={true} key={`${index}_${message}`}>
+            {message}
+          </StyledFormHelperText>
+        ))}
+      </FormControl>
+    );
+  };
+  

--- a/viestinvalitys-raportointi/src/app/components/OrganisaatioSelect.tsx
+++ b/viestinvalitys-raportointi/src/app/components/OrganisaatioSelect.tsx
@@ -14,7 +14,7 @@ import {
 } from '../lib/util';
 import OrganisaatioHierarkia from './OrganisaatioHierarkia';
 import { useQuery } from '@tanstack/react-query';
-import { Typography } from '@opetushallitus/oph-design-system';
+import { OphTypography } from '@opetushallitus/oph-design-system';
 import { NUQS_DEFAULT_OPTIONS } from '../lib/constants';
 import { useTranslation } from '../i18n/clientLocalization';
 import { useLocale } from '../i18n/locale-provider';
@@ -115,9 +115,9 @@ const OrganisaatioSelect = () => {
   const lng = useLocale(); 
   return (
     <>
-      <Typography component="div" sx={{ ml: 2, flexGrow: 1, color: 'black' }}>
+      <OphTypography component="div" sx={{ ml: 2, flexGrow: 1, color: 'black' }}>
         {translateOrgName(selectedOrg, lng)} 
-      </Typography>
+      </OphTypography>
       <IconButton onClick={toggleDrawer(true)} title={t('organisaatio.vaihda')}>
         <MenuIcon />
       </IconButton>
@@ -128,9 +128,9 @@ const OrganisaatioSelect = () => {
         sx={{ padding: 2 }}
       >
         <OrganisaatioFilter />
-        <Typography component="div">
+        <OphTypography component="div">
           {t('organisaatio.valittu', {organisaatioNimi: translateOrgName(selectedOrg, lng)})}
-        </Typography>
+        </OphTypography>
         {isLoading ? (
           <ClientSpinner />
         ) : (

--- a/viestinvalitys-raportointi/src/app/components/OrganisaatioSelect.tsx
+++ b/viestinvalitys-raportointi/src/app/components/OrganisaatioSelect.tsx
@@ -19,6 +19,7 @@ import { NUQS_DEFAULT_OPTIONS } from '../lib/constants';
 import { useTranslation } from '../i18n/clientLocalization';
 import { useLocale } from '../i18n/locale-provider';
 import { getLocale } from '../i18n/localization';
+import { ClientSpinner } from './ClientSpinner';
 
 export const StyledDrawer = styled(Drawer)(({theme}) => ({
   '& .MuiDrawer-paper': {
@@ -131,7 +132,7 @@ const OrganisaatioSelect = () => {
           {t('organisaatio.valittu', {organisaatioNimi: translateOrgName(selectedOrg, lng)})}
         </Typography>
         {isLoading ? (
-          <Typography>{t('yleinen.ladataan')}</Typography>
+          <ClientSpinner />
         ) : (
           <OrganisaatioHierarkia
             organisaatiot={data ?? []}

--- a/viestinvalitys-raportointi/src/app/components/StyledTable.tsx
+++ b/viestinvalitys-raportointi/src/app/components/StyledTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Table, TableBody, TableCell, styled } from "@mui/material";
-import { colors } from "../theme";
+import { ophColors } from "@opetushallitus/oph-design-system";
 
 export const StyledTable = styled(Table)({
     width: '100%',
@@ -14,13 +14,13 @@ export const StyledTable = styled(Table)({
     whiteSpace: 'pre-wrap',
     borderWidth: 0,
     'button:focus': {
-      color: colors.blue2,
+      color: ophColors.blue2,
     },
   });
 
   
   export const StyledHeaderCell = styled(TableCell)({
-    background: colors.white,
+    background: ophColors.white,
     verticalAlign: 'bottom',
     paddingBottom: '0.5rem',
   });
@@ -28,10 +28,10 @@ export const StyledTable = styled(Table)({
 export const StyledTableBody = styled(TableBody)({
     '& .MuiTableRow-root': {
       '&:nth-of-type(even)': {
-        backgroundColor: colors.grey50,
+        backgroundColor: ophColors.grey50,
       },
       '&:hover': {
-        backgroundColor: colors.lightBlue2,
+        backgroundColor: ophColors.lightBlue2,
       },
     },
   });

--- a/viestinvalitys-raportointi/src/app/hooks/useHydration.ts
+++ b/viestinvalitys-raportointi/src/app/hooks/useHydration.ts
@@ -1,9 +1,0 @@
-import { useEffect, useState } from 'react';
-
-export function useHydration() {
-  const [hydrated, setHydrated] = useState(false);
-  useEffect(() => {
-    setHydrated(true);
-  }, []);
-  return hydrated;
-}

--- a/viestinvalitys-raportointi/src/app/i18n/locales/fi.json
+++ b/viestinvalitys-raportointi/src/app/i18n/locales/fi.json
@@ -13,6 +13,7 @@
       "mista-haetaan": "Mistä haetaan",
       "vastaanottaja": "Vastaanottaja",
       "lahettaja": "Lähettäjä",
+      "lahettava-palvelu": "Viestin lähettänyt palvelu",
       "otsikko-sisalto": "Otsikko ja sisältö",
       "eituloksia": "Hakuehdoilla ei löytynyt tuloksia",
       "tila": "Tila",

--- a/viestinvalitys-raportointi/src/app/i18n/locales/fi.json
+++ b/viestinvalitys-raportointi/src/app/i18n/locales/fi.json
@@ -66,6 +66,8 @@
   "error": {
     "404.otsikko": "Sivua ei löytynyt",
     "404.teksti": "Etsittyä sivua ei löytynyt.",
+    "access-denied": "Ei riittäviä käyttöoikeuksia",
+    "fetch": "Tietojen haussa tapahtui virhe",
     "otsikko": "Tapahtui virhe",
     "teksti": "Palvelussa tapahtui virhe."
   },

--- a/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/Vastaanottajat.tsx
+++ b/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/Vastaanottajat.tsx
@@ -10,7 +10,7 @@ import { getLahetysStatus } from '../../lib/util';
 import { StatusIcon } from '@/app/components/LahetysStatus';
 import ViewViesti from './ViewViesti';
 import { StyledCell, StyledHeaderCell, StyledTable, StyledTableBody } from '@/app/components/StyledTable';
-import { Typography } from '@opetushallitus/oph-design-system';
+import { OphTypography } from '@opetushallitus/oph-design-system';
 import { useTranslation } from '@/app/i18n/clientLocalization';
 
 const VastaanottajanStatus = ({
@@ -33,7 +33,7 @@ const VastaanottajanStatus = ({
 const Toiminnot = ({ tila }: { tila: VastaanotonTila }) => {
   const { t } = useTranslation();
   if (getLahetysStatus([tila]) === Status.EPAONNISTUI) {
-    return <Typography>{t('vastaanottaja.laheta-uudelleen')}</Typography>;
+    return <OphTypography>{t('vastaanottaja.laheta-uudelleen')}</OphTypography>;
   }
   return <></>;
 };

--- a/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/ViewViesti.tsx
+++ b/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/ViewViesti.tsx
@@ -13,16 +13,15 @@ import {
 import { fetchViesti } from '@/app/lib/data';
 import { Viesti } from '@/app/lib/types';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Typography } from '@opetushallitus/oph-design-system';
+import { OphButton, ophColors, OphTypography } from '@opetushallitus/oph-design-system';
 import CloseIcon from '@mui/icons-material/Close';
-import { colors } from '@/app/theme';
 import { useTranslation } from '@/app/i18n/clientLocalization';
 
 const closeButtonStyle = {
     position: 'absolute',
     right: "2px",
     top: "2px",
-    color: colors.grey500,
+    color: ophColors.grey500,
   };
 
 const ViestiModal = ({
@@ -46,7 +45,7 @@ const ViestiModal = ({
   });
   const { t } = useTranslation();
   if (isLoading) {
-    return <Typography>{t('yleinen.ladataan')}</Typography>;
+    return <OphTypography>{t('yleinen.ladataan')}</OphTypography>;
   }
   return (
     <Dialog
@@ -55,7 +54,7 @@ const ViestiModal = ({
       aria-labelledby="viesti-dialog-title"
       aria-describedby="viesti-dialog-description"
     >
-      <DialogTitle id="viesti-dialog-title" component="h3" sx={{borderTop: 4, borderTopColor: colors.blue2}}>
+      <DialogTitle id="viesti-dialog-title" component="h3" sx={{borderTop: 4, borderTopColor: ophColors.blue2}}>
         {data?.otsikko ?? t('viesti.ei-otsikkoa')}
         <IconButton aria-label={t('yleinen.sulje')} onClick={handleClose} sx={closeButtonStyle}>
           <CloseIcon />
@@ -72,14 +71,14 @@ const ViestiModal = ({
               }}
             />
           ) : (
-            <Typography id="modal-viestisisalto" sx={{ mt: 2 }}>
+            <OphTypography id="modal-viestisisalto" sx={{ mt: 2 }}>
               {data?.sisalto ?? t('viesti.ei-sisaltoa')}
-            </Typography>
+            </OphTypography>
           )}
         </DialogContentText>
       </DialogContent>
       <DialogActions sx={{justifyContent: 'flex-start'}}>
-        <Button variant='contained' onClick={handleClose}>{t('yleinen.sulje')}</Button>
+        <OphButton variant='contained' onClick={handleClose}>{t('yleinen.sulje')}</OphButton>
       </DialogActions>
     </Dialog>
   );
@@ -101,7 +100,7 @@ export default function ViewViesti({
   return (
     <>
     
-      <Button onClick={handleOpen}>{t('viesti.nayta')}</Button>
+      <OphButton onClick={handleOpen}>{t('viesti.nayta')}</OphButton>
       {viestiOpen ? (
         <ViestiModal
           viestiTunniste={viestiTunniste}

--- a/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/ViewViesti.tsx
+++ b/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/ViewViesti.tsx
@@ -38,8 +38,7 @@ const ViestiModal = ({
     return response;
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data, isLoading, error, refetch } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['fetchViesti', viestiTunniste],
     queryFn: () => doFetchViesti(viestiTunniste),
   });

--- a/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/page.tsx
+++ b/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/page.tsx
@@ -22,7 +22,6 @@ import { GreyDivider } from '@/app/components/GreyDivider';
 import { SearchParams } from 'nuqs/server';
 import { searchParamsCache } from '@/app/lib/searchParams';
 import { initTranslations } from '@/app/i18n/localization';
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const LahetyksenTiedot = async ({ lahetys }: { lahetys: Lahetys }) => {  
 
   const { t } = await initTranslations();

--- a/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/page.tsx
+++ b/viestinvalitys-raportointi/src/app/lahetys/[tunniste]/page.tsx
@@ -23,7 +23,8 @@ import { SearchParams } from 'nuqs/server';
 import { searchParamsCache } from '@/app/lib/searchParams';
 import { initTranslations } from '@/app/i18n/localization';
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const LahetyksenTiedot = async ({ lahetys }: { lahetys: Lahetys }) => {
+const LahetyksenTiedot = async ({ lahetys }: { lahetys: Lahetys }) => {  
+
   const { t } = await initTranslations();
   return (
     <Grid container spacing={2} padding={2}>

--- a/viestinvalitys-raportointi/src/app/layout.tsx
+++ b/viestinvalitys-raportointi/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
 import NavAppBar from './components/NavAppBar';
-import { CssBaseline, ThemeProvider } from '@mui/material';
-import theme from './theme';
+import { CssBaseline } from '@mui/material';
 import ReactQueryClientProvider from './components/react-query-client-provider';
 import { PageLayout } from './components/PageLayout';
 import { getLocale, initTranslations } from './i18n/localization';
 import type { Metadata } from 'next';
 import { LocaleProvider } from './i18n/locale-provider';
+import { OphNextJsThemeProvider } from '@opetushallitus/oph-design-system/next/theme';
 
 export async function generateMetadata(): Promise<Metadata> {
   const { t } = await initTranslations();
@@ -27,12 +27,12 @@ export default async function RootLayout({
       <body>
         <AppRouterCacheProvider>
           <ReactQueryClientProvider>
-            <ThemeProvider theme={theme}>
+            <OphNextJsThemeProvider variant="oph" lang={locale}>
               <CssBaseline />
               <LocaleProvider value={locale}>
                 <PageLayout header={<NavAppBar />}>{children}</PageLayout>
               </LocaleProvider>
-            </ThemeProvider>
+            </OphNextJsThemeProvider>
           </ReactQueryClientProvider>
         </AppRouterCacheProvider>
       </body>

--- a/viestinvalitys-raportointi/src/app/lib/data.ts
+++ b/viestinvalitys-raportointi/src/app/lib/data.ts
@@ -3,19 +3,14 @@ import { cookies } from 'next/headers';
 import { LahetysHakuParams, OrganisaatioSearchResult, VastaanottajatHakuParams } from './types';
 import { apiUrl, cookieName, loginUrl, virkailijaUrl } from './configurations';
 import { redirect } from 'next/navigation';
+import { makeRequest } from './http-client';
 
 const LAHETYKSET_SIVUTUS_KOKO = 20;
 const VASTAANOTTAJAT_SIVUTUS_KOKO = 10;
 const REVALIDATE_TIME_SECONDS = 60 * 60 * 2;
 const REVALIDATE_ASIOINTIKIELI = 60;
 
-// TODO apuwrapperi headerien asettamiseen ja virheenkäsittelyyn
 export async function fetchLahetykset(hakuParams: LahetysHakuParams) {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const fetchUrlBase = `${apiUrl}/lahetykset/lista?enintaan=${LAHETYKSET_SIVUTUS_KOKO}`;
   // eslint-disable-next-line no-var
   var fetchParams = hakuParams.seuraavatAlkaen
@@ -30,53 +25,24 @@ export async function fetchLahetykset(hakuParams: LahetysHakuParams) {
   if(hakuParams?.palvelu) {
     fetchParams += `&palvelu=${hakuParams.palvelu}`;
   }
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(fetchUrlBase.concat(fetchParams), {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(fetchUrlBase.concat(fetchParams), {
     cache: 'no-store',
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      console.info('http 401, redirect to login');
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function fetchLahetys(lahetysTunnus: string) {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/lahetykset/${lahetysTunnus}`;
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url, {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(url, {
     cache: 'no-store',
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function fetchLahetyksenVastaanottajat(
   lahetysTunnus: string,
   hakuParams: VastaanottajatHakuParams,
 ) {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/lahetykset/${lahetysTunnus}/vastaanottajat?enintaan=${VASTAANOTTAJAT_SIVUTUS_KOKO}`;
   // eslint-disable-next-line no-var
   var fetchParams = hakuParams.alkaen
@@ -91,90 +57,38 @@ export async function fetchLahetyksenVastaanottajat(
   if (hakuParams?.organisaatio) {
     fetchParams += `&organisaatio=${hakuParams.organisaatio}`;
   }
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url.concat(fetchParams), {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(url.concat(fetchParams), {
     cache: 'no-store',
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function fetchMassaviesti(lahetysTunnus: string) {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/massaviesti/${lahetysTunnus}`;
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url, {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(url, {
     cache: 'no-store',
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function fetchViesti(viestiTunnus: string) {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/viesti/${viestiTunnus}`;
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url, {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(url, {
     cache: 'no-store',
   });
-  console.info(res.status);
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error(res.statusText);
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function fetchAsiointikieli() {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    console.info(loginUrl);
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/omattiedot`;
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url, {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(url, {
     next: { revalidate: REVALIDATE_ASIOINTIKIELI }
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error('asiointikielen haku epäonnistui');
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function fetchLokalisaatiot(lang: string) {
+  // ei tarvi käyttää http-clientia kun ei vaadi tunnistautumista ja on tiedostot fallbackina
   const url = `${virkailijaUrl}/lokalisointi/cxf/rest/v1/localisation?category=viestinvalitys&locale=`;
   const res = await fetch(`${url}${lang}`, {
     next: { revalidate: REVALIDATE_TIME_SECONDS },
@@ -183,34 +97,15 @@ export async function fetchLokalisaatiot(lang: string) {
 }
 
 export async function fetchOrganisaatioRajoitukset() {
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/organisaatiot/oikeudet`;
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url, {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
-    cache: 'no-store', // caching in backend
+  const res = await makeRequest(url, {
+    cache: 'no-store',
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error('organisaatio-oikeuksien haku epäonnistui');
-  }
-  return res.json();
+  return res.data;
 }
 
 export async function searchOrganisaatio(searchStr: string): Promise<OrganisaatioSearchResult> {
   console.info('haetaan organisaatiota');
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   // organisaatiorajaus oikeuksien mukaan
   const oidRestrictionList: string[] = await fetchOrganisaatioRajoitukset();
   const oidRestrictionParams =
@@ -224,33 +119,14 @@ export async function searchOrganisaatio(searchStr: string): Promise<Organisaati
       csrf: '1.2.246.562.10.00000000001.viestinvalityspalvelu',
     },
   });
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error('organisaation haku epäonnistui');
-  }
   return res.json();
 }
 
 export async function fetchLahettavatPalvelut(): Promise<string[]> {
   console.info('haetaan lähettävät palvelut');
-  const sessionCookie = cookies().get(cookieName);
-  if (sessionCookie === undefined) {
-    console.info('no session cookie, redirect to login');
-    redirect(loginUrl);
-  }
   const url = `${apiUrl}/palvelut`;
-  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
-  const res = await fetch(url, {
-    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+  const res = await makeRequest(url, {
     cache: 'no-store',
   });
-  console.info(res.status)
-  if (!(res.ok || res.status === 400 || res.status === 410)) {
-    if (res.status === 401) {
-      redirect(loginUrl);
-    }
-    // This will activate the closest `error.js` Error Boundary
-    throw new Error('lähettävien palvelujen haku epäonnistui');
-  }
-  return res.json();
+  return res.data;
 }

--- a/viestinvalitys-raportointi/src/app/lib/data.ts
+++ b/viestinvalitys-raportointi/src/app/lib/data.ts
@@ -27,6 +27,9 @@ export async function fetchLahetykset(hakuParams: LahetysHakuParams) {
   if (hakuParams?.organisaatio) {
     fetchParams += `&organisaatio=${hakuParams.organisaatio}`;
   }
+  if(hakuParams?.palvelu) {
+    fetchParams += `&palvelu=${hakuParams.palvelu}`;
+  }
   const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
   const res = await fetch(fetchUrlBase.concat(fetchParams), {
     headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
@@ -224,6 +227,28 @@ export async function searchOrganisaatio(searchStr: string): Promise<Organisaati
   if (!(res.ok || res.status === 400 || res.status === 410)) {
     // This will activate the closest `error.js` Error Boundary
     throw new Error('organisaation haku epäonnistui');
+  }
+  return res.json();
+}
+
+export async function fetchLahettavatPalvelut(): Promise<string[]> {
+  const sessionCookie = cookies().get(cookieName);
+  if (sessionCookie === undefined) {
+    console.info('no session cookie, redirect to login');
+    redirect(loginUrl);
+  }
+  const url = `${apiUrl}/palvelut`;
+  const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
+  const res = await fetch(url, {
+    headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
+    next: { revalidate: REVALIDATE_TIME_SECONDS },
+  });
+  if (!(res.ok || res.status === 400 || res.status === 410)) {
+    if (res.status === 401) {
+      redirect(loginUrl);
+    }
+    // This will activate the closest `error.js` Error Boundary
+    throw new Error('lähettävien palvelujen haku epäonnistui');
   }
   return res.json();
 }

--- a/viestinvalitys-raportointi/src/app/lib/data.ts
+++ b/viestinvalitys-raportointi/src/app/lib/data.ts
@@ -126,5 +126,6 @@ export async function fetchLahettavatPalvelut(): Promise<string[]> {
   const res = await makeRequest(url, {
     cache: 'no-store',
   });
+  console.info(res.data)
   return res.data;
 }

--- a/viestinvalitys-raportointi/src/app/lib/data.ts
+++ b/viestinvalitys-raportointi/src/app/lib/data.ts
@@ -121,11 +121,9 @@ export async function searchOrganisaatio(searchStr: string): Promise<Organisaati
 }
 
 export async function fetchLahettavatPalvelut(): Promise<string[]> {
-  console.info('haetaan lähettävät palvelut');
   const url = `${apiUrl}/palvelut`;
   const res = await makeRequest(url, {
     cache: 'no-store',
   });
-  console.info(res.data)
   return res.data;
 }

--- a/viestinvalitys-raportointi/src/app/lib/data.ts
+++ b/viestinvalitys-raportointi/src/app/lib/data.ts
@@ -232,6 +232,7 @@ export async function searchOrganisaatio(searchStr: string): Promise<Organisaati
 }
 
 export async function fetchLahettavatPalvelut(): Promise<string[]> {
+  console.info('haetaan lähettävät palvelut');
   const sessionCookie = cookies().get(cookieName);
   if (sessionCookie === undefined) {
     console.info('no session cookie, redirect to login');
@@ -241,8 +242,9 @@ export async function fetchLahettavatPalvelut(): Promise<string[]> {
   const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
   const res = await fetch(url, {
     headers: { cookie: cookieParam ?? '' }, // Forward the authorization header
-    next: { revalidate: REVALIDATE_TIME_SECONDS },
+    cache: 'no-store',
   });
+  console.info(res.status)
   if (!(res.ok || res.status === 400 || res.status === 410)) {
     if (res.status === 401) {
       redirect(loginUrl);

--- a/viestinvalitys-raportointi/src/app/lib/data.ts
+++ b/viestinvalitys-raportointi/src/app/lib/data.ts
@@ -1,8 +1,6 @@
 'use server'; // täytyy olla eksplisiittisesti koska käytetään client-komponentista react-querylla
-import { cookies } from 'next/headers';
 import { LahetysHakuParams, OrganisaatioSearchResult, VastaanottajatHakuParams } from './types';
-import { apiUrl, cookieName, loginUrl, virkailijaUrl } from './configurations';
-import { redirect } from 'next/navigation';
+import { apiUrl, virkailijaUrl } from './configurations';
 import { makeRequest } from './http-client';
 
 const LAHETYKSET_SIVUTUS_KOKO = 20;

--- a/viestinvalitys-raportointi/src/app/lib/error-handling.ts
+++ b/viestinvalitys-raportointi/src/app/lib/error-handling.ts
@@ -1,0 +1,16 @@
+export class FetchError extends Error {
+    response: Response;
+    constructor(response: Response, message: string = 'error.fetch') {
+      super(message);
+      // Set the prototype explicitly.
+      Object.setPrototypeOf(this, FetchError.prototype);
+      this.response = response;
+    }
+  }
+  
+  export class PermissionError extends Error {
+    constructor(message: string = 'error.access-denied') {
+      super(message);
+    }
+  }
+  

--- a/viestinvalitys-raportointi/src/app/lib/http-client.ts
+++ b/viestinvalitys-raportointi/src/app/lib/http-client.ts
@@ -1,0 +1,101 @@
+import { redirect } from 'next/navigation';
+import { apiUrl, cookieName, loginUrl } from './configurations';
+import { FetchError } from "./error-handling";
+import { cookies } from 'next/headers';
+
+/* sovellettu valintojen-totettaminen repon vastaavasta */
+const doFetch = async (request: Request) => {
+    try {
+      const response = await fetch(request);
+      return response.status >= 400
+        ? Promise.reject(new FetchError(response))
+        : Promise.resolve(response);
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  };
+  
+  const isUnauthenticated = (response: Response) => {
+    return response?.status === 401;
+  };
+  
+  const isRedirected = (response: Response) => {
+    return response.redirected;
+  };
+  
+  const makeBareRequest = (request: Request) => {
+    request.headers.set('Caller-Id', '1.2.246.562.10.00000000001.viestinvalityspalvelu');
+    request.headers.set('CSRF', '1.2.246.562.10.00000000001.viestinvalityspalvelu')  
+    return doFetch(request);
+  };
+  
+  const retryWithLogin = async (request: Request, loginUrl: string) => {
+    await makeBareRequest(new Request(loginUrl));
+    return makeBareRequest(request);
+  };
+
+  const responseToData = async (res: Response) => {
+    if (res.status === 204) {
+      return { data: {} };
+    }
+    try {
+        const result = { data: await res.json() }; // toistaiseksi kaikki kutsuttavat apit palauttavat jsonia
+        return result;
+      } catch (e) {
+        console.error('Parsing fetch response body as JSON failed!');
+        return Promise.reject(e);
+      }
+  };
+
+  export const makeRequest = async (url: string, options: RequestInit = {}) => {
+    console.info('Tehdään request urliin ' + url)
+    // autentikointicookie
+    const sessionCookie = cookies().get(cookieName);
+    if (sessionCookie === undefined) {
+        redirect(loginUrl);
+    }
+    const cookieParam = sessionCookie.name + '=' + sessionCookie.value;
+    const request = new Request(url, { method: 'GET', headers: { cookie: cookieParam ?? '' }, ...options })
+    const originalRequest = request.clone();
+    try {
+      const response = await makeBareRequest(request);
+      const responseUrl = new URL(response.url);
+      if (
+        isRedirected(response) &&
+        responseUrl.pathname.startsWith('/cas/login')
+      ) {
+        redirect(loginUrl);
+      }
+      return responseToData(response);
+    } catch (error: unknown) {
+      console.error('Virhe tietojen haussa')
+      if (error instanceof FetchError) {
+        console.error(error.response.status)
+        console.error(error.message)
+        if (isUnauthenticated(error.response)) {
+          try {
+            if (request?.url?.includes(apiUrl)) {
+                const resp = await retryWithLogin(request, loginUrl);
+                return responseToData(resp);
+              }
+          } catch (e) {
+            if (e instanceof FetchError && isUnauthenticated(e.response)) {
+                redirect(loginUrl);
+            }
+            return Promise.reject(e);
+          }
+        } else if (
+          isRedirected(error.response) &&
+          error.response.url === request.url
+        ) {
+          //Some backend services lose the original method and headers, so we need to do retry with cloned request
+          const response = await makeBareRequest(originalRequest);
+          return responseToData(response);
+        }
+      }
+      return Promise.reject(error);
+    }
+  };
+
+  
+  

--- a/viestinvalitys-raportointi/src/app/lib/searchParams.ts
+++ b/viestinvalitys-raportointi/src/app/lib/searchParams.ts
@@ -4,6 +4,7 @@ export const searchParamsCache = createSearchParamsCache({
     seuraavatAlkaen: parseAsString,
     hakukentta: parseAsString,
     hakusana: parseAsString,
+    palvelu: parseAsString,
     organisaatio: parseAsString,
     alkaen: parseAsString,
     tila: parseAsString

--- a/viestinvalitys-raportointi/src/app/lib/types.ts
+++ b/viestinvalitys-raportointi/src/app/lib/types.ts
@@ -2,6 +2,7 @@ export type LahetysHakuParams = {
   seuraavatAlkaen: string | null;
   hakukentta: string | null;
   hakusana: string | null;
+  palvelu: string | null;
   organisaatio: string | null;
 };
 

--- a/viestinvalitys-raportointi/src/app/page.tsx
+++ b/viestinvalitys-raportointi/src/app/page.tsx
@@ -9,7 +9,7 @@ import VirheAlert from './components/VirheAlert';
 import LahetyksetTable from './LahetyksetTable';
 import LahetyksetSivutus from './LahetyksetSivutus';
 import { LahetysHakuParams } from './lib/types';
-import { fetchLahetykset } from './lib/data';
+import { fetchLahettavatPalvelut, fetchLahetykset } from './lib/data';
 import { initTranslations } from './i18n/localization';
 
 const Lahetykset = async () => {
@@ -46,10 +46,11 @@ type PageProps = {
 export default async function Page({ searchParams }: PageProps) {
 
   searchParamsCache.parse(searchParams) // pitää alustaa tässä jotta toimii lahetykset-komponentissa
+  const palvelut = await fetchLahettavatPalvelut();
   return (
     <MainContainer>
       <Suspense fallback={<Loading />}>
-        <Haku />
+        <Haku lahettavatPalvelut={palvelut} />
         <Lahetykset />
       </Suspense>
     </MainContainer>

--- a/viestinvalitys-raportointi/src/app/page.tsx
+++ b/viestinvalitys-raportointi/src/app/page.tsx
@@ -17,6 +17,7 @@ const Lahetykset = async () => {
     seuraavatAlkaen: searchParamsCache.get('seuraavatAlkaen'),
     hakukentta: searchParamsCache.get('hakukentta'),
     hakusana: searchParamsCache.get('hakusana'),
+    palvelu: searchParamsCache.get('palvelu'),
     organisaatio: searchParamsCache.get('organisaatio'),
   }
   const data = await fetchLahetykset(fetchParams);

--- a/viestinvalitys-raportointi/src/app/theme.tsx
+++ b/viestinvalitys-raportointi/src/app/theme.tsx
@@ -1,29 +1,5 @@
 'use client';
 import * as React from 'react';
-import { MUI_NEXTJS_OVERRIDES } from '@opetushallitus/oph-design-system/next/theme';
-import { createStyled } from '@mui/system';
-import { deepmerge } from '@mui/utils';
-
-import { createODSTheme } from '@opetushallitus/oph-design-system/theme';
-
-import { colors, aliasColors } from '@opetushallitus/oph-design-system';
-
-export { colors, aliasColors };
-
-export const DEFAULT_BOX_BORDER = `2px solid ${colors.grey100}`;
-
-const theme = createODSTheme({
-  variant: 'oph',
-  overrides: deepmerge(MUI_NEXTJS_OVERRIDES, {
-    components: {
-      MuiButtonBase: {
-        defaultProps: {
-          disableRipple: true,
-        },
-      },
-    },
-  }),
-});
 
 // MUI:sta (Emotionista) puuttuu styled-componentsin .attrs
 // Tällä voi asettaa oletus-propsit ilman, että tarvii luoda välikomponenttia
@@ -41,6 +17,3 @@ export function withDefaultProps<P>(
   return ComponentWithDefaultProps;
 }
 
-export const styled = createStyled({ defaultTheme: theme });
-
-export default theme;


### PR DESCRIPTION
Listaus lähettävistä palveluista bäkkäriin. 
- haetaan lähetyksistä joita voi olla iso massa, mutta en lähtenyt ennenaikaiseen optimointiin
- toistaiseksi ei ole tehty erillistä aputaulua vaan lisätty indeksointi

Lähettävät palvelut käliin hakukriteeriksi.
- Kälisuunnitelman mukaan select-valikko. Jos tulee jossain kohtaa pitempi lista, voinee harkita autocompletea
- otettu samalla käyttöön uusi versio oph-design-systemistä ja OphSelect-komponentti
- Mukailtu OphFormControl-komponentti uudesta valintakälistä - jossain kohti design systemiin
 
Pohjana branch OK-606_haku joka ei ole vielä mainissa, koska hakutoiminnot sisältävät kantamuutoksia joita vielä testataan QA:lla ja vietävä hallitusti tuotantoon.