### PR TITLE
OY-5211 viestinvälityspalvelu-clientille voi antaa http clientin parametrina

### DIFF
--- a/kirjasto/src/main/scala/fi.oph.viestinvalitys/ViestinvalitysClient.java
+++ b/kirjasto/src/main/scala/fi.oph.viestinvalitys/ViestinvalitysClient.java
@@ -2,6 +2,7 @@ package fi.oph.viestinvalitys;
 
 import fi.oph.viestinvalitys.vastaanotto.model.*;
 import fi.oph.viestinvalitys.vastaanotto.resource.VastaanottajaResponseImpl;
+import org.asynchttpclient.AsyncHttpClient;
 
 import java.util.List;
 import java.util.UUID;
@@ -46,5 +47,7 @@ public interface ViestinvalitysClient {
   interface ViestinValitysClientBuilder {
 
     ViestinvalitysClient build();
+    
+    ViestinvalitysClient buildWithHttpClient(AsyncHttpClient httpClient);
   }
 }


### PR DESCRIPTION
viestinvälityspalvelu-clientille voi antaa cas-clientin käyttämän http clientin parametrina.